### PR TITLE
Added responders as an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This GitHub Action allows you to create alerts in [OpsGenie](https://www.atlassi
 - **\`tags\`**: Tags of the alert, separated by commas.
 - **\`priority\`**: Priority level of the alert. Possible values are P1, P2, P3, P4 and P5. Default value is P3.
 - **\`using_eu_url\`**: Set the action to use OpsGenie europe endpoint 'https://api.eu.opsgenie.com'. Defaults to false
+- **\`responders\`**: The responders of the alert. Defaults to json string array.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: Boolean, true if using Opsgenie EU API endpoint
     required: false
     default: "false"
+  responders:
+    description: JSON string, representing an array of responders with type and name keys
+    required: false
+    default: "[]"
 runs:
   using: "node16"
   main: "dist/index.js"

--- a/index.js
+++ b/index.js
@@ -11,6 +11,13 @@ const allInputs = () => {
   const inputs = {};
   for (let [k, v] of Object.entries(process.env)) {
     if (k.startsWith("INPUT_")) {
+      try {
+        const parsedValue = JSON.parse(v);
+        if (Array.isArray(parsedValue)) {
+          inputs[k.toLowerCase().substring(6)] = parsedValue;
+          continue
+        }
+      } catch (error) {}
       inputs[k.toLowerCase().substring(6)] = v;
     }
   }


### PR DESCRIPTION
Added responders as an optional parameter to support creating Opsgenie Alerts for specific responders or teams.

Example Usage:
```yaml
- name: Create OpsGenie Alert for Specific Responder
  uses: rockem/create-opsgenie-alert-action@v1
  with:
    api_key: ${{ secrets.OPSGENIE_API_KEY }}
    message: >
      Activity exceeded timeout: exceeded 60 seconds
    alias: "workflow-failure"
    source: "GitHub Actions"
    responders: '[{"name":"your_team_name", "type":"team"}]'
```